### PR TITLE
bug/resize large widget and fairbow placement correction

### DIFF
--- a/frontend/public/widget/co2okWidgetL.css
+++ b/frontend/public/widget/co2okWidgetL.css
@@ -9,7 +9,8 @@
       padding: 2px;
       position: relative;
       width: 150px;
-    height:75px; 
+    height:75px;
+    margin-bottom: 16px;
   }
   
   .large-widget-right-green {

--- a/frontend/public/widget/co2okWidgetL.css
+++ b/frontend/public/widget/co2okWidgetL.css
@@ -31,16 +31,17 @@
   
   #large-widget-text {
     position:absolute;
-    font:7px Poppins, Verdana, sans-serif;
+    font:8px Poppins, Verdana, sans-serif;
     font-weight:400;
     color:#606468;
-    margin-top: 10px;
+    margin-top: 5px;
     margin-left:3px;
     z-index:3;
+    line-height: 1.8;
   }
   
   #large-widget-text-large {
-    font:11px Poppins, Verdana, sans-serif;
+    font:10.5px Poppins, Verdana, sans-serif;
     color:#606468;
     font-weight: bold;
   }
@@ -61,21 +62,21 @@
     position: absolute;
     z-index:4;
     width:25%;
-    margin-top:50px;
+    margin-top:52px;
     margin-left: 4px;
   }
   
   #info-button-widget {
     position:absolute;
-    margin-top:48px;
-    margin-left:48px;
+    margin-top:52px;
+    margin-left:49px;
     z-index:5;
-    width:9%;
+    width:8%;
   }
   
   #large-widget-airplane {
     position:absolute;
-    margin-top:40px;
+    margin-top:38px;
     margin-left:103px;
     z-index:6;
     width:18%;

--- a/frontend/public/widget/co2okWidgetL.css
+++ b/frontend/public/widget/co2okWidgetL.css
@@ -34,7 +34,7 @@
     font:8px Poppins, Verdana, sans-serif;
     font-weight:400;
     color:#606468;
-    margin-top: 5px;
+    margin-top: 6px;
     margin-left:3px;
     z-index:3;
     line-height: 1.8;

--- a/frontend/public/widget/co2okWidgetL.css
+++ b/frontend/public/widget/co2okWidgetL.css
@@ -50,7 +50,7 @@
   #large-widget-xvliegen {
     position:relative;
     float:right;
-    font:9px Poppins, Verdana, sans-serif;
+    font:8.5px Poppins, Verdana, sans-serif;
     color:white;
     font-weight: bold;
     margin-top:6px;

--- a/frontend/public/widget/co2okWidgetXL.css
+++ b/frontend/public/widget/co2okWidgetXL.css
@@ -9,7 +9,8 @@
       padding: 2px;
       position: relative;
       width: 250px;
-    height:125px; 
+    height:125px;
+    margin-bottom: 16px;
   }
   
   .large-widget-right-green {

--- a/frontend/public/widget/co2okWidgetXL.js
+++ b/frontend/public/widget/co2okWidgetXL.js
@@ -44,8 +44,8 @@ let Co2okWidgetXL = {
 
         // get impact from API
         let xhr = Co2okWidgetXL.xhr()
-        // let host = 'http://127.0.0.1:8000'
-        let host = 'https://app.co2ok.eco'
+        let host = 'http://127.0.0.1:8000'
+        // let host = 'https://app.co2ok.eco'
         xhr.open('GET', `${host}/user/totalCompensationData/?merchantId=${merchantId}`, true)
         //    xhr.withCredentials = true;
            xhr.onreadystatechange = function(){
@@ -76,13 +76,14 @@ let Co2okWidgetXL = {
         // Mijnkraamshop: D0C918
         let color = "#D0C918"
         // Het zou een idee zijn om deze te verduidelijken tov de host var hierboven
-        let  SITE_HOST =  'https://co2ok.eco'
-        // let SITE_HOST = 'http://localhost:8080'
+        // let  SITE_HOST =  'https://co2ok.eco'
+        let SITE_HOST = 'http://localhost:8080'
   
         var fileref=document.createElement("link")
         fileref.setAttribute("rel", "stylesheet")
         fileref.setAttribute("type", "text/css")
         fileref.setAttribute("href", `${SITE_HOST}/widget/co2okWidgetMark.css`)
+        console.log("here", document.getElementsByTagName("head")[0].appendChild(fileref))
         document.getElementsByTagName("head")[0].appendChild(fileref)
         
         if (Co2okWidgetXL.getCookieValue('co2ok_ab_hide') == '0')
@@ -108,7 +109,7 @@ let Co2okWidgetXL = {
                 }
                 
                   if (widgetSize == "L") {
-                    var circleSize = '> <circle cx="51" cy="39.5" r="38" fill="white">';
+                    var circleSize = '> <circle cx="61" cy="39.5" r="37.5" fill="white">';
                     var fileref=document.createElement("link")
                     fileref.setAttribute("rel", "stylesheet")
                     fileref.setAttribute("type", "text/css")

--- a/frontend/public/widget/co2okWidgetXL.js
+++ b/frontend/public/widget/co2okWidgetXL.js
@@ -44,8 +44,8 @@ let Co2okWidgetXL = {
 
         // get impact from API
         let xhr = Co2okWidgetXL.xhr()
-        let host = 'http://127.0.0.1:8000'
-        // let host = 'https://app.co2ok.eco'
+        // let host = 'http://127.0.0.1:8000'
+        let host = 'https://app.co2ok.eco'
         xhr.open('GET', `${host}/user/totalCompensationData/?merchantId=${merchantId}`, true)
         //    xhr.withCredentials = true;
            xhr.onreadystatechange = function(){
@@ -76,14 +76,13 @@ let Co2okWidgetXL = {
         // Mijnkraamshop: D0C918
         let color = "#D0C918"
         // Het zou een idee zijn om deze te verduidelijken tov de host var hierboven
-        // let  SITE_HOST =  'https://co2ok.eco'
-        let SITE_HOST = 'http://localhost:8080'
+        let  SITE_HOST =  'https://co2ok.eco'
+        // let SITE_HOST = 'http://localhost:8080'
   
         var fileref=document.createElement("link")
         fileref.setAttribute("rel", "stylesheet")
         fileref.setAttribute("type", "text/css")
         fileref.setAttribute("href", `${SITE_HOST}/widget/co2okWidgetMark.css`)
-        console.log("here", document.getElementsByTagName("head")[0].appendChild(fileref))
         document.getElementsByTagName("head")[0].appendChild(fileref)
         
         if (Co2okWidgetXL.getCookieValue('co2ok_ab_hide') == '0')


### PR DESCRIPTION
slight changes to large widget for readability. Increased font size and adjusted placement of text, logo, and circle. screenshoots don't really show that huge of difference haha but I promise, there are!

Previous style:
<img width="202" alt="Screenshot 2020-10-27 at 16 31 49" src="https://user-images.githubusercontent.com/45078521/97324314-ff634900-1871-11eb-889f-4ea030f1ce44.png">

With fixes applied: 
<img width="286" alt="Screenshot 2020-10-27 at 16 23 43" src="https://user-images.githubusercontent.com/45078521/97323614-44d34680-1871-11eb-9585-e0de993884f5.png">

margin-bottom was added to the css for widget L and XL to ensure the widget will not overlap or hug elements on shop page

XL:
<img width="399" alt="Screenshot 2020-10-27 at 16 39 50" src="https://user-images.githubusercontent.com/45078521/97327469-46067280-1875-11eb-9b3d-3c31c26820a5.png">

L:
<img width="371" alt="Screenshot 2020-10-27 at 16 56 38" src="https://user-images.githubusercontent.com/45078521/97327576-646c6e00-1875-11eb-9bbc-b34ffbe9c1cb.png">

